### PR TITLE
Update serverless and set concurrency limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN yum -y install nodejs npm yarn python27
 RUN yarn global add node-gyp
 
 # serverless
-RUN yarn global add serverless@1.37
+RUN yarn global add serverless@1.38
 
 # working directory
 ADD ./ /code

--- a/config.json
+++ b/config.json
@@ -5,12 +5,18 @@
     "sourceBucket": "staging-uploads-visualpedia.igg.cloud",
     "sourcePrefix": "",
     "destinationBucket": "staging-images-visualpedia.igg.cloud",
-    "destinationPrefix": "images/"
+    "destinationPrefix": "images/",
+    "reservedConcurrency": 10,
+    "memorySize": 2048,
+    "timeout": 300
   },
   "production": {
     "sourceBucket": "production-uploads-visualpedia.igg.cloud",
     "sourcePrefix": "",
     "destinationBucket": "production-images-visualpedia.igg.cloud",
-    "destinationPrefix": "images/"
+    "destinationPrefix": "images/",
+    "reservedConcurrency": 50,
+    "memorySize": 2560,
+    "timeout": 360
   }
 }

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     "destinationPrefix": "images/",
     "reservedConcurrency": 10,
     "memorySize": 2048,
-    "timeout": 300
+    "timeout": 600
   },
   "production": {
     "sourceBucket": "production-uploads-visualpedia.igg.cloud",
@@ -17,6 +17,6 @@
     "destinationPrefix": "images/",
     "reservedConcurrency": 50,
     "memorySize": 2560,
-    "timeout": 360
+    "timeout": 720
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -64,9 +64,9 @@ provider:
 functions:
   resizeImage:
     handler: handler.process
-    timeout: 360
-    memorySize: 2560
-    reservedConcurrency: 50
+    timeout: ${file(config.json):${self:provider.stage}.timeout}
+    memorySize: ${file(config.json):${self:provider.stage}.memorySize}
+    reservedConcurrency: ${file(config.json):${self:provider.stage}.reservedConcurrency}
     description: Resize Images
     events:
       - existingS3:

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-frameworkVersion: "^1.37.1"
+frameworkVersion: "^1.38.0"
 
 service:
   name: visualpedia-s3-images

--- a/serverless.yml
+++ b/serverless.yml
@@ -64,8 +64,9 @@ provider:
 functions:
   resizeImage:
     handler: handler.process
-    timeout: 300
-    memorySize: 2048
+    timeout: 360
+    memorySize: 2560
+    reservedConcurrency: 50
     description: Resize Images
     events:
       - existingS3:


### PR DESCRIPTION
- Update serverless to the latest version
- configure stage specific limits. (in config.json)
- set concurrency limit to 50/10 concurrent invocations (previously 1000)
- set the time out to 12/10 minutes (previously 5 minutes)
- set the memory size to 2560MB -2.5GB-/2048 (previously 2048MB... maximum allowed on AWS is 3008MB) 

the limits are expanded in production than on staging